### PR TITLE
Add Auralog design system and screen mocks

### DIFF
--- a/macOS_TypoZero_ChatGPT/auralog-design.html
+++ b/macOS_TypoZero_ChatGPT/auralog-design.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Auralog · Design System & Screens</title>
+  <link rel="stylesheet" href="auralog-style.css" />
+</head>
+<body>
+  <div class="app" data-theme="light">
+    <div class="wrapper">
+      <header class="header">
+        <div class="brand">
+          <div class="brand__logo">Au</div>
+          <div>
+            <div style="font-weight: 700; font-size: 18px;">Auralog</div>
+            <div style="color: var(--text-muted);">Soft Rounded Friendly UI kit</div>
+          </div>
+          <span class="badge">Light + Dark</span>
+        </div>
+        <button class="theme-toggle" onclick="toggleTheme()">
+          <span aria-hidden="true">🌗</span>
+          <span>Toggle theme</span>
+        </button>
+      </header>
+
+      <section class="panel">
+        <h3 class="section-title">Typography &amp; Color Tokens</h3>
+        <div class="grid two">
+          <div class="typography-sample card" aria-label="typography scale">
+            <h1>Title · 32</h1>
+            <h2>H1 · 26</h2>
+            <h3>H2 · 20</h3>
+            <h4>H3 · 17</h4>
+            <p>Body · 15 — calm, intelligent voice that emphasizes clarity.</p>
+            <small>Caption · 13 — timestamps, helper labels, secondary text.</small>
+          </div>
+          <div class="card" aria-label="color tokens">
+            <div class="token-row">
+              <div class="color-swatch" style="background: var(--primary); color:#fff;">Primary</div>
+              <div class="color-swatch" style="background: var(--bg-app);">Bg</div>
+              <div class="color-swatch" style="background: var(--bg-surface);">Surface</div>
+              <div class="color-swatch" style="background: var(--bg-subtle);">Subtle</div>
+              <div class="color-swatch" style="background: var(--success); color:#fff;">Success</div>
+              <div class="color-swatch" style="background: var(--warning); color:#fff;">Warning</div>
+              <div class="color-swatch" style="background: var(--error); color:#fff;">Error</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h3 class="section-title">Buttons &amp; Inputs</h3>
+        <div class="grid two">
+          <div class="card">
+            <div class="button-row">
+              <button class="btn primary">Primary</button>
+              <button class="btn secondary">Secondary</button>
+              <button class="btn ghost">Ghost</button>
+              <button class="btn destructive">Destructive</button>
+              <button class="btn icon-only" aria-label="icon button">+</button>
+              <button class="btn primary">Icon + Label</button>
+            </div>
+          </div>
+          <div class="grid two">
+            <div class="input-group">
+              <label>Text Field</label>
+              <input class="input" type="text" placeholder="Speaker name" />
+            </div>
+            <div class="dropzone">Drop audio here or browse</div>
+            <div class="select">
+              <span>Language</span>
+              <select class="input">
+                <option>English (US)</option>
+                <option>German</option>
+              </select>
+            </div>
+            <div class="toggle">
+              <span>Speaker diarization</span>
+              <div class="toggle-pill is-on"></div>
+            </div>
+            <div class="slider">
+              <span>Audio scrubber</span>
+              <input type="range" value="60" />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h3 class="section-title">Cards &amp; Navigation</h3>
+        <div class="grid two">
+          <div class="grid three">
+            <div class="card recording-card">
+              <h4>Recording Item</h4>
+              <p>Duration · 52:17 · 2 speakers</p>
+              <div class="waveform"></div>
+            </div>
+            <div class="card">
+              <h4>AI Processing</h4>
+              <p>Status: Summarizing</p>
+              <div class="progress-bar"><span></span></div>
+            </div>
+            <div class="card">
+              <h4>Analytics</h4>
+              <p>Meetings this week: 6 · Avg clarity 94%</p>
+            </div>
+          </div>
+          <div class="sidebar-sample">
+            <div class="sidebar">
+              <button class="is-active">Dashboard</button>
+              <button>Projects</button>
+              <button>Settings</button>
+              <button>Help</button>
+            </div>
+            <div class="topbar">
+              <div class="breadcrumbs">Projects / Auralog</div>
+              <div class="nav">
+                <button class="btn ghost">Search</button>
+                <button class="btn primary">New Import</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h3 class="section-title">System Components</h3>
+        <div class="system-row">
+          <div class="modal">
+            <strong>Modal</strong>
+            <p>Request AI rerun with updated prompt?</p>
+            <div class="action-row">
+              <button class="btn secondary">Cancel</button>
+              <button class="btn primary">Run</button>
+            </div>
+          </div>
+          <div class="toast">
+            <strong>Toast</strong>
+            <p>Transcript regenerated with action items.</p>
+          </div>
+          <div class="progress">
+            <strong>Progress</strong>
+            <div class="progress-bar"><span></span></div>
+            <div class="c-progress"></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h3 class="section-title">Screens (Light &amp; Dark)</h3>
+        <div class="grid two">
+          <div class="screen-mock">
+            <div class="screen-header">
+              <div>
+                <div class="screen-title">Onboarding</div>
+                <p class="responsive-note">Calm hero, CTA to import audio or view sample.</p>
+              </div>
+              <button class="btn primary">Import Audio</button>
+            </div>
+            <div class="audio-tile">
+              <strong>"Convert speech into structured knowledge."</strong>
+              <p>Soft gradient illustration, friendly spacing.</p>
+            </div>
+            <div class="action-row">
+              <button class="btn secondary">View Sample Project</button>
+              <button class="btn ghost">Learn how it works</button>
+            </div>
+          </div>
+
+          <div class="screen-mock">
+            <div class="screen-header">
+              <div class="screen-title">Dashboard</div>
+              <div class="action-row">
+                <button class="btn secondary">New Import</button>
+                <button class="btn ghost">Create Folder</button>
+              </div>
+            </div>
+            <div class="grid two">
+              <div class="project-card">
+                <strong>Design Sync</strong>
+                <p>Updated 2h ago · 42m · Transcript ready</p>
+              </div>
+              <div class="project-card">
+                <strong>Quarterly Review</strong>
+                <p>Yesterday · 1h12m · Summaries in progress</p>
+              </div>
+              <div class="project-card">
+                <strong>Research Interviews</strong>
+                <p>Sorted by date · folder view</p>
+              </div>
+              <div class="project-card">
+                <strong>Sales Calls</strong>
+                <p>Metadata: speakers, clarity, language</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="screen-mock">
+            <div class="screen-header">
+              <div class="screen-title">Recording Import</div>
+              <span class="badge">Wizard</span>
+            </div>
+            <div class="dropzone">Drag & drop audio files</div>
+            <div class="audio-tile">
+              <strong>design-review.wav</strong>
+              <p>52:17 · 2 speakers · English</p>
+            </div>
+            <div class="grid two">
+              <div class="select"><span>Language</span><select class="input"><option>English</option></select></div>
+              <div class="select"><span>AI Detail</span><select class="input"><option>Concise</option><option>Verbose</option></select></div>
+            </div>
+            <div class="toggle"><span>Speaker diarization</span><div class="toggle-pill is-on"></div></div>
+            <div class="progress-bar"><span></span></div>
+          </div>
+
+          <div class="screen-mock">
+            <div class="screen-header">
+              <div class="screen-title">Transcript + Notes</div>
+              <div class="action-row">
+                <button class="btn ghost">Search</button>
+                <button class="btn secondary">Export</button>
+                <button class="btn ghost">Regenerate</button>
+              </div>
+            </div>
+            <div class="grid two">
+              <div class="audio-tile">
+                <strong>00:05 · Alex</strong>
+                <p>"Let's finalize the launch narrative and owners."</p>
+                <strong>00:12 · Priya</strong>
+                <p>"Action items include QA sign-off and sales enablement."</p>
+              </div>
+              <div class="summary-card">
+                <strong>AI Notes</strong>
+                <p>Summary, decisions, action items with highlights per speaker.</p>
+              </div>
+            </div>
+            <div class="waveform"></div>
+          </div>
+
+          <div class="screen-mock">
+            <div class="screen-header">
+              <div class="screen-title">Settings</div>
+              <p class="responsive-note">Output formats, AI parameters, storage, account.</p>
+            </div>
+            <div class="settings-card">
+              <strong>Outputs</strong>
+              <p>Markdown, DOCX, PDF</p>
+            </div>
+            <div class="settings-card">
+              <strong>AI Parameters</strong>
+              <p>Temperature 0.4 · Summary style: action-focused</p>
+            </div>
+            <div class="settings-card">
+              <strong>Storage</strong>
+              <p>Auto-delete after 90 days · Manage local cache</p>
+            </div>
+            <div class="settings-card">
+              <strong>Account</strong>
+              <p>API key · Plan · Connected services</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h3 class="section-title">Responsive &amp; Motion</h3>
+        <p class="responsive-note">Narrow layouts shift grids to single column; toolbar groups wrap; cards stretch with consistent 16px padding.</p>
+        <p class="motion-note">Motion keeps easing subtle (120–200ms). Hover lifts, panel fade-ins, progress animations only. Avoid playful bounces.</p>
+      </section>
+    </div>
+  </div>
+
+  <script>
+    function toggleTheme() {
+      const app = document.querySelector('.app');
+      const next = app.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+      app.setAttribute('data-theme', next);
+    }
+  </script>
+</body>
+</html>

--- a/macOS_TypoZero_ChatGPT/auralog-style.css
+++ b/macOS_TypoZero_ChatGPT/auralog-style.css
@@ -1,0 +1,434 @@
+/* Auralog design system: soft rounded, calm, intelligent */
+:root {
+  --font-sans: "Inter", "SF Pro Display", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --bg-app: #f7f8fa;
+  --bg-surface: #ffffff;
+  --bg-subtle: #f1f2f5;
+  --text-strong: #2b2d31;
+  --text-muted: #5b5e66;
+  --text-soft: #7a7d86;
+  --primary: #3a6ff7;
+  --primary-strong: #355fd6;
+  --primary-soft: #e7eeff;
+  --success: #2fb37b;
+  --warning: #f2a93b;
+  --error: #e45b5b;
+  --border: #e0e4eb;
+  --shadow-soft: 0 12px 32px rgba(28, 36, 56, 0.12);
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --space-1: 6px;
+  --space-2: 10px;
+  --space-3: 14px;
+  --space-4: 18px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 40px;
+  --gradient-accent: linear-gradient(140deg, #3a6ff7 0%, #5c64f8 50%, #5f57f8 100%);
+  --glass: rgba(255, 255, 255, 0.8);
+}
+
+.app[data-theme="dark"] {
+  --bg-app: #0d1017;
+  --bg-surface: #10131c;
+  --bg-subtle: #171c28;
+  --text-strong: #e4e7f1;
+  --text-muted: #b3b8c6;
+  --text-soft: #8f96aa;
+  --primary: #6e8bff;
+  --primary-strong: #5471ea;
+  --primary-soft: #1f2940;
+  --success: #49d09b;
+  --warning: #f4b756;
+  --error: #f57a7a;
+  --border: #1f2535;
+  --shadow-soft: 0 18px 44px rgba(0, 0, 0, 0.45);
+  --glass: rgba(16, 19, 28, 0.7);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: var(--bg-app);
+  color: var(--text-strong);
+  -webkit-font-smoothing: antialiased;
+}
+
+.app {
+  min-height: 100vh;
+  padding: var(--space-6);
+  background: radial-gradient(circle at 10% 20%, rgba(90, 110, 255, 0.08), transparent 28%),
+    radial-gradient(circle at 80% 0%, rgba(74, 105, 255, 0.08), transparent 30%),
+    var(--bg-app);
+  transition: background 220ms ease, color 220ms ease;
+}
+
+.wrapper {
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.brand__logo {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: var(--gradient-accent);
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  box-shadow: var(--shadow-soft);
+}
+
+.badge {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--primary-soft);
+  color: var(--primary-strong);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  color: var(--text-strong);
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+.theme-toggle:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-soft);
+}
+
+.panel {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  box-shadow: var(--shadow-soft);
+  margin-bottom: var(--space-6);
+  backdrop-filter: blur(16px);
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-3);
+  font-size: 18px;
+}
+
+.grid {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.grid.two {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.grid.three {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.token-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.color-swatch {
+  width: 72px;
+  height: 64px;
+  border-radius: var(--radius-md);
+  box-shadow: inset 0 0 0 1px var(--border);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 8px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.typography-sample h1,
+.typography-sample h2,
+.typography-sample h3,
+.typography-sample h4,
+.typography-sample p,
+.typography-sample small {
+  margin: 0 0 10px;
+}
+
+.typography-sample h1 { font-size: 32px; letter-spacing: -0.4px; }
+.typography-sample h2 { font-size: 26px; letter-spacing: -0.3px; }
+.typography-sample h3 { font-size: 20px; letter-spacing: -0.2px; }
+.typography-sample h4 { font-size: 17px; font-weight: 600; }
+.typography-sample p { font-size: 15px; color: var(--text-muted); }
+.typography-sample small { font-size: 13px; color: var(--text-soft); }
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+  background: var(--bg-subtle);
+  color: var(--text-strong);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+}
+
+.btn:hover { transform: translateY(-1px); box-shadow: var(--shadow-soft); }
+
+.btn.primary { background: var(--gradient-accent); color: #fff; }
+.btn.secondary { border-color: var(--border); }
+.btn.ghost { background: transparent; border-color: transparent; color: var(--text-muted); }
+.btn.destructive { background: #ffecec; color: var(--error); border-color: rgba(228,91,91,0.3); }
+.btn.icon-only { padding: 10px; width: 44px; justify-content: center; }
+
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.input {
+  padding: 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg-subtle);
+  color: var(--text-strong);
+  outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+.input:focus {
+  border-color: var(--primary);
+  background: #fff;
+  box-shadow: 0 0 0 3px rgba(58, 111, 247, 0.15);
+}
+
+.dropzone {
+  border: 1.5px dashed var(--border);
+  background: var(--bg-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.select,
+.slider,
+.toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.toggle-pill {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: var(--primary-soft);
+  border: 1px solid var(--border);
+  position: relative;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+
+.toggle-pill::after {
+  content: "";
+  position: absolute;
+  top: 3px; left: 3px;
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.12);
+  transition: transform 150ms ease;
+}
+
+.toggle-pill.is-on { background: var(--primary); border-color: transparent; }
+.toggle-pill.is-on::after { transform: translateX(20px); }
+
+.slider input[type="range"] { width: 180px; accent-color: var(--primary); }
+
+.card {
+  padding: var(--space-4);
+  background: var(--bg-subtle);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.4);
+}
+
+.card h4 { margin: 0 0 6px; }
+.card p { margin: 0; color: var(--text-muted); }
+
+.nav,
+.topbar {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.sidebar-sample {
+  display: grid;
+  grid-template-columns: 180px 1fr;
+  gap: var(--space-4);
+}
+
+.sidebar {
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  display: grid;
+  gap: 6px;
+}
+
+.sidebar button {
+  background: transparent;
+  border: none;
+  padding: 10px;
+  text-align: left;
+  border-radius: var(--radius-md);
+  color: var(--text-strong);
+  cursor: pointer;
+}
+
+.sidebar button:hover,
+.sidebar button.is-active { background: var(--primary-soft); color: var(--primary-strong); }
+
+.topbar {
+  justify-content: space-between;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 12px 16px;
+  box-shadow: var(--shadow-soft);
+}
+
+.breadcrumbs { color: var(--text-muted); font-size: 13px; }
+
+.system-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-3);
+}
+
+.modal,
+.toast,
+.progress { background: var(--bg-subtle); border: 1px solid var(--border); border-radius: var(--radius-md); padding: var(--space-3); }
+
+.progress-bar {
+  width: 100%;
+  height: 8px;
+  background: var(--bg-app);
+  border-radius: 999px;
+  position: relative;
+  overflow: hidden;
+}
+
+.progress-bar span {
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 60%;
+  background: var(--gradient-accent);
+  border-radius: 999px;
+}
+
+.c-progress {
+  width: 72px; height: 72px;
+  border-radius: 50%;
+  background: conic-gradient(var(--primary) 0deg 240deg, var(--bg-app) 240deg 360deg);
+  display: grid;
+  place-items: center;
+  position: relative;
+}
+
+.c-progress::after {
+  content: "";
+  width: 52px; height: 52px;
+  background: var(--bg-subtle);
+  border-radius: 50%;
+  border: 1px solid var(--border);
+}
+
+.screen-mock {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: var(--space-3);
+}
+
+.screen-header { display: flex; align-items: center; justify-content: space-between; gap: var(--space-2); }
+.screen-title { font-weight: 700; }
+
+.audio-tile,
+.project-card,
+.summary-card,
+.settings-card {
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  display: grid;
+  gap: 6px;
+}
+
+.waveform { height: 60px; border-radius: 12px; background: linear-gradient(90deg, rgba(58,111,247,0.14), rgba(58,111,247,0)); }
+
+.action-row { display: flex; gap: 8px; flex-wrap: wrap; }
+
+.responsive-note, .motion-note { color: var(--text-muted); font-size: 13px; margin: 0; }
+
+@media (max-width: 1100px) {
+  .sidebar-sample { grid-template-columns: 1fr; }
+  .header { flex-direction: column; align-items: flex-start; }
+}
+
+@media (max-width: 720px) {
+  .panel { padding: var(--space-4); }
+  .grid.two { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+  .screen-mock { padding: var(--space-3); }
+}


### PR DESCRIPTION
## Summary
- create an Auralog design reference page covering typography, color tokens, core components, and system elements
- add screen mock layouts for onboarding, dashboard, import flow, transcript workspace, and settings with light/dark styles
- include soft-rounded theme tokens, responsive rules, and motion guidance

## Testing
- not run (design-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69293669436083319de6802b90e028f3)