### PR TITLE
JetBrains Plugin: Go Table Test Viewer (MVP)

### DIFF
--- a/jetbrains-go-tabletest-viewer/.gitignore
+++ b/jetbrains-go-tabletest-viewer/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/jetbrains-go-tabletest-viewer/README.md
+++ b/jetbrains-go-tabletest-viewer/README.md
@@ -1,0 +1,39 @@
+# JetBrains Go Table Test Viewer
+
+A JetBrains IDE plugin (IntelliJ Platform) to view and navigate Go table-driven tests.
+
+## Features
+
+- **Table Tests Tool Window**: Displays a tree view of test packages, files, functions, and cases.
+- **Navigation**: Double-click a test case to jump to the corresponding line in the source code.
+- **Filtering**: Search bar to filter test cases by name or description.
+- **Refresh**: Re-run the analysis to update the view.
+
+## Requirements
+
+This plugin requires an external CLI tool `testlist` to be installed and available on your system.
+The `testlist` tool must output JSON in the expected schema.
+
+## Installation
+
+1. Build the plugin using Gradle:
+   ```bash
+   ./gradlew buildPlugin
+   ```
+2. Install the generated ZIP file (located in `build/distributions/`) via **Settings > Plugins > Gear Icon > Install Plugin from Disk...**.
+
+## Configuration
+
+1. Go to **Settings/Preferences > Tools > Test Table Viewer**.
+2. Set the **Testlist executable path**.
+   - Default: `testlist` (assumes it is in your system PATH).
+   - If `testlist` is not in PATH, provide the absolute path.
+
+## Usage
+
+1. Open a Go project.
+2. Open the **Table Tests** tool window (usually on the right side).
+3. Click **Refresh** to load the test cases.
+4. Expand the tree to see cases.
+5. Use the search bar to filter cases.
+6. Double-click a case to jump to the code.

--- a/jetbrains-go-tabletest-viewer/build.gradle.kts
+++ b/jetbrains-go-tabletest-viewer/build.gradle.kts
@@ -1,0 +1,37 @@
+plugins {
+    id("java")
+    id("org.jetbrains.kotlin.jvm") version "1.9.23"
+    id("org.jetbrains.intellij") version "1.17.3"
+}
+
+group = project.findProperty("pluginGroup").toString()
+version = project.findProperty("pluginVersion").toString()
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.google.code.gson:gson:2.10.1")
+    testImplementation("junit:junit:4.13.2")
+}
+
+intellij {
+    version.set(project.findProperty("platformVersion").toString())
+    type.set(project.findProperty("platformType").toString())
+}
+
+tasks {
+    withType<JavaCompile> {
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
+    }
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions.jvmTarget = "17"
+    }
+
+    patchPluginXml {
+        sinceBuild.set(project.findProperty("pluginSinceBuild").toString())
+        untilBuild.set(project.findProperty("pluginUntilBuild").toString())
+    }
+}

--- a/jetbrains-go-tabletest-viewer/gradle.properties
+++ b/jetbrains-go-tabletest-viewer/gradle.properties
@@ -1,0 +1,7 @@
+pluginGroup = com.github.mypkg
+pluginName = jetbrains-go-tabletest-viewer
+pluginVersion = 1.0.0
+platformVersion = 2024.1
+platformType = IC
+pluginSinceBuild = 241
+pluginUntilBuild = 241.*

--- a/jetbrains-go-tabletest-viewer/settings.gradle.kts
+++ b/jetbrains-go-tabletest-viewer/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "jetbrains-go-tabletest-viewer"

--- a/jetbrains-go-tabletest-viewer/src/main/kotlin/com/github/mypkg/model/TestListSchema.kt
+++ b/jetbrains-go-tabletest-viewer/src/main/kotlin/com/github/mypkg/model/TestListSchema.kt
@@ -1,0 +1,31 @@
+package com.github.mypkg.model
+
+import com.google.gson.annotations.SerializedName
+
+data class TestListResult(
+    val version: Int,
+    val packages: List<Package>
+)
+
+data class Package(
+    val importPath: String,
+    val files: List<File>
+)
+
+data class File(
+    val path: String,
+    val tests: List<Test>
+)
+
+data class Test(
+    @SerializedName("func") val funcName: String,
+    val cases: List<Case>
+)
+
+data class Case(
+    val name: String,
+    val desc: String?,
+    val line: Int,
+    val col: Int,
+    val source: String?
+)

--- a/jetbrains-go-tabletest-viewer/src/main/kotlin/com/github/mypkg/service/TestListService.kt
+++ b/jetbrains-go-tabletest-viewer/src/main/kotlin/com/github/mypkg/service/TestListService.kt
@@ -1,0 +1,60 @@
+package com.github.mypkg.service
+
+import com.github.mypkg.model.TestListResult
+import com.github.mypkg.settings.AppSettingsState
+import com.google.gson.Gson
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.project.Project
+import java.nio.charset.StandardCharsets
+
+@Service(Service.Level.PROJECT)
+class TestListService(private val project: Project) {
+
+    @Throws(Exception::class)
+    fun runTestList(indicator: ProgressIndicator? = null): TestListResult {
+        val settings = AppSettingsState.instance
+        val commandPath = settings.testListPath
+
+        if (commandPath.isBlank()) {
+            throw Exception("Testlist executable path is not configured.")
+        }
+
+        val basePath = project.basePath ?: throw Exception("Project base path is not available.")
+
+        val commandLine = GeneralCommandLine()
+            .withExePath(commandPath)
+            .withParameters("--json", ".")
+            .withWorkDirectory(basePath)
+            .withCharset(StandardCharsets.UTF_8)
+
+        val output = try {
+            val handler = CapturingProcessHandler(commandLine)
+            if (indicator != null) {
+                handler.runProcessWithProgressIndicator(indicator)
+            } else {
+                handler.runProcess()
+            }
+        } catch (e: Exception) {
+            throw Exception("Failed to start testlist: ${e.message}. Please check the executable path in Settings.", e)
+        }
+
+        if (output.exitCode != 0) {
+            val errorMsg = if (output.stderr.isNotBlank()) output.stderr else "Exit code: ${output.exitCode}"
+            throw Exception("testlist execution failed: $errorMsg")
+        }
+
+        val json = output.stdout
+        if (json.isBlank()) {
+             throw Exception("testlist returned empty output.")
+        }
+
+        return try {
+            Gson().fromJson(json, TestListResult::class.java)
+        } catch (e: Exception) {
+            throw Exception("Failed to parse JSON output: ${e.message}", e)
+        }
+    }
+}

--- a/jetbrains-go-tabletest-viewer/src/main/kotlin/com/github/mypkg/settings/AppSettingsConfigurable.kt
+++ b/jetbrains-go-tabletest-viewer/src/main/kotlin/com/github/mypkg/settings/AppSettingsConfigurable.kt
@@ -1,0 +1,45 @@
+package com.github.mypkg.settings
+
+import com.intellij.openapi.options.Configurable
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBTextField
+import com.intellij.util.ui.FormBuilder
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+class AppSettingsConfigurable : Configurable {
+
+    private var mySettingsComponent: JPanel? = null
+    private val myPathField = JBTextField()
+
+    override fun getDisplayName(): String = "Test Table Viewer"
+
+    override fun getPreferredFocusedComponent(): JComponent = myPathField
+
+    override fun createComponent(): JComponent {
+        mySettingsComponent = FormBuilder.createFormBuilder()
+            .addLabeledComponent(JBLabel("Testlist executable path:"), myPathField, 1, false)
+            .addComponentFillVertically(JPanel(), 0)
+            .panel
+        return mySettingsComponent!!
+    }
+
+    override fun isModified(): Boolean {
+        val settings = AppSettingsState.instance
+        return myPathField.text != settings.testListPath
+    }
+
+    override fun apply() {
+        val settings = AppSettingsState.instance
+        settings.testListPath = myPathField.text
+    }
+
+    override fun reset() {
+        val settings = AppSettingsState.instance
+        myPathField.text = settings.testListPath
+    }
+
+    override fun disposeUIResources() {
+        mySettingsComponent = null
+    }
+}

--- a/jetbrains-go-tabletest-viewer/src/main/kotlin/com/github/mypkg/settings/AppSettingsState.kt
+++ b/jetbrains-go-tabletest-viewer/src/main/kotlin/com/github/mypkg/settings/AppSettingsState.kt
@@ -1,0 +1,31 @@
+package com.github.mypkg.settings
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+@State(
+    name = "com.github.mypkg.settings.AppSettingsState",
+    storages = [Storage("TestListPluginSettings.xml")]
+)
+@Service(Service.Level.APP)
+class AppSettingsState : PersistentStateComponent<AppSettingsState> {
+
+    var testListPath: String = "testlist"
+
+    override fun getState(): AppSettingsState {
+        return this
+    }
+
+    override fun loadState(state: AppSettingsState) {
+        XmlSerializerUtil.copyBean(state, this)
+    }
+
+    companion object {
+        val instance: AppSettingsState
+            get() = ApplicationManager.getApplication().getService(AppSettingsState::class.java)
+    }
+}

--- a/jetbrains-go-tabletest-viewer/src/main/kotlin/com/github/mypkg/ui/TableTestNodes.kt
+++ b/jetbrains-go-tabletest-viewer/src/main/kotlin/com/github/mypkg/ui/TableTestNodes.kt
@@ -1,0 +1,27 @@
+package com.github.mypkg.ui
+
+import com.github.mypkg.model.Package
+import com.github.mypkg.model.File
+import com.github.mypkg.model.Test
+import com.github.mypkg.model.Case
+import javax.swing.tree.DefaultMutableTreeNode
+
+sealed class BaseNode(userObject: Any) : DefaultMutableTreeNode(userObject)
+
+class RootNode : BaseNode("Root")
+
+class PackageNode(val pkg: Package) : BaseNode(pkg) {
+    override fun toString() = pkg.importPath
+}
+
+class FileNode(val file: File) : BaseNode(file) {
+    override fun toString() = file.path
+}
+
+class TestNode(val test: Test) : BaseNode(test) {
+    override fun toString() = test.funcName
+}
+
+class CaseNode(val case: Case, val file: File) : BaseNode(case) {
+    override fun toString() = if (case.desc.isNullOrEmpty()) case.name else "${case.name} (${case.desc})"
+}

--- a/jetbrains-go-tabletest-viewer/src/main/kotlin/com/github/mypkg/ui/TableTestToolWindowFactory.kt
+++ b/jetbrains-go-tabletest-viewer/src/main/kotlin/com/github/mypkg/ui/TableTestToolWindowFactory.kt
@@ -1,0 +1,15 @@
+package com.github.mypkg.ui
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.content.ContentFactory
+
+class TableTestToolWindowFactory : ToolWindowFactory {
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val myToolWindow = TableTestWindow(project)
+        val contentFactory = ContentFactory.getInstance()
+        val content = contentFactory.createContent(myToolWindow.content, "", false)
+        toolWindow.contentManager.addContent(content)
+    }
+}

--- a/jetbrains-go-tabletest-viewer/src/main/kotlin/com/github/mypkg/ui/TableTestWindow.kt
+++ b/jetbrains-go-tabletest-viewer/src/main/kotlin/com/github/mypkg/ui/TableTestWindow.kt
@@ -1,0 +1,229 @@
+package com.github.mypkg.ui
+
+import com.github.mypkg.model.TestListResult
+import com.github.mypkg.service.TestListService
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.ui.ColoredTreeCellRenderer
+import com.intellij.ui.DocumentAdapter
+import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.treeStructure.Tree
+import java.awt.BorderLayout
+import java.awt.FlowLayout
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.JButton
+import javax.swing.JPanel
+import javax.swing.JTree
+import javax.swing.event.DocumentEvent
+import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.DefaultTreeModel
+
+class TableTestWindow(private val project: Project) {
+
+    val content: JPanel = JPanel(BorderLayout())
+    private val treeModel = DefaultTreeModel(RootNode())
+    private val tree = Tree(treeModel)
+    private var lastResult: TestListResult? = null
+    private val searchField = JBTextField()
+
+    @Volatile
+    private var currentIndicator: ProgressIndicator? = null
+
+    init {
+        setupUI()
+        refreshData()
+    }
+
+    private fun setupUI() {
+        // Top Toolbar
+        val topPanel = JPanel(BorderLayout())
+
+        // Search
+        searchField.emptyText.text = "Search cases..."
+        searchField.document.addDocumentListener(object : DocumentAdapter() {
+            override fun textChanged(e: DocumentEvent) {
+                updateTree(searchField.text)
+            }
+        })
+        topPanel.add(searchField, BorderLayout.CENTER)
+
+        // Refresh Button
+        val refreshBtn = JButton("Refresh") // Ideally use AnAction with icon, but JButton is simple for MVP
+        refreshBtn.addActionListener { refreshData() }
+        topPanel.add(refreshBtn, BorderLayout.EAST)
+
+        content.add(topPanel, BorderLayout.NORTH)
+
+        // Tree
+        tree.isRootVisible = false
+        tree.addMouseListener(object : MouseAdapter() {
+            override fun mouseClicked(e: MouseEvent) {
+                if (e.clickCount == 2) {
+                    val node = tree.lastSelectedPathComponent as? DefaultMutableTreeNode ?: return
+                    if (node is CaseNode) {
+                        navigate(node)
+                    }
+                }
+            }
+        })
+        tree.cellRenderer = object : ColoredTreeCellRenderer() {
+            override fun customizeCellRenderer(
+                tree: JTree,
+                value: Any?,
+                selected: Boolean,
+                expanded: Boolean,
+                leaf: Boolean,
+                row: Int,
+                hasFocus: Boolean
+            ) {
+                if (value is BaseNode) {
+                    when (value) {
+                        is PackageNode -> {
+                            icon = AllIcons.Nodes.Package
+                            append(value.pkg.importPath)
+                        }
+                        is FileNode -> {
+                            icon = AllIcons.FileTypes.Text
+                            append(value.file.path)
+                        }
+                        is TestNode -> {
+                            icon = AllIcons.RunConfigurations.TestState.Run
+                            append(value.test.funcName)
+                        }
+                        is CaseNode -> {
+                            icon = AllIcons.Nodes.Test
+                            append(value.case.name)
+                            val desc = value.case.desc
+                            if (!desc.isNullOrEmpty()) {
+                                append("  ($desc)", SimpleTextAttributes.GRAYED_ATTRIBUTES)
+                            }
+                        }
+                        is RootNode -> {
+                            // Root is invisible
+                        }
+                    }
+                }
+            }
+        }
+
+        content.add(JBScrollPane(tree), BorderLayout.CENTER)
+    }
+
+    private fun refreshData() {
+        val previous = currentIndicator
+        previous?.cancel()
+
+        object : Task.Backgroundable(project, "Running testlist...", true) {
+            override fun run(indicator: ProgressIndicator) {
+                currentIndicator = indicator
+                try {
+                    val service = project.getService(TestListService::class.java)
+                    val result = service.runTestList(indicator)
+                    ApplicationManager.getApplication().invokeLater {
+                        lastResult = result
+                        updateTree(searchField.text)
+                    }
+                } catch (e: com.intellij.openapi.progress.ProcessCanceledException) {
+                    // Task was cancelled, ignore
+                } catch (e: Exception) {
+                    if (indicator.isCanceled) return
+
+                    ApplicationManager.getApplication().invokeLater {
+                        Messages.showErrorDialog(project, e.message, "Testlist Failed")
+                        // Clear tree or show error node
+                        val errorRoot = RootNode()
+                        errorRoot.add(DefaultMutableTreeNode("Error: ${e.message}"))
+                        treeModel.setRoot(errorRoot)
+                    }
+                } finally {
+                    if (currentIndicator == indicator) {
+                        currentIndicator = null
+                    }
+                }
+            }
+        }.queue()
+    }
+
+    private fun updateTree(filter: String) {
+        val result = lastResult ?: return
+        val root = RootNode()
+        val lowerFilter = filter.lowercase()
+
+        result.packages.forEach { pkg ->
+            val pkgNode = PackageNode(pkg)
+            var pkgHasMatch = false
+
+            pkg.files.forEach { file ->
+                val fileNode = FileNode(file)
+                var fileHasMatch = false
+
+                file.tests.forEach { test ->
+                    val testNode = TestNode(test)
+                    var testHasMatch = false
+
+                    test.cases.forEach { case ->
+                        // Filter logic: Match name or desc
+                        val match = if (filter.isBlank()) true else {
+                            case.name.lowercase().contains(lowerFilter) ||
+                            (case.desc?.lowercase()?.contains(lowerFilter) == true)
+                        }
+
+                        if (match) {
+                            val caseNode = CaseNode(case, file)
+                            testNode.add(caseNode)
+                            testHasMatch = true
+                        }
+                    }
+
+                    if (testHasMatch) {
+                        fileNode.add(testNode)
+                        fileHasMatch = true
+                    }
+                }
+
+                if (fileHasMatch) {
+                    pkgNode.add(fileNode)
+                    pkgHasMatch = true
+                }
+            }
+
+            if (pkgHasMatch) {
+                root.add(pkgNode)
+            }
+        }
+
+        treeModel.setRoot(root)
+
+        // Expand all if filtering, otherwise maybe just packages?
+        // MVP: Expand all for now if filter is active
+        if (filter.isNotBlank()) {
+            for (i in 0 until tree.rowCount) {
+                tree.expandRow(i)
+            }
+        }
+    }
+
+    private fun navigate(node: CaseNode) {
+        val filePath = node.file.path
+        val line = node.case.line - 1 // 1-origin to 0-origin
+        val col = node.case.col - 1
+
+        val rootPath = project.basePath ?: return
+        val virtualFile = LocalFileSystem.getInstance().findFileByPath("$rootPath/$filePath")
+
+        if (virtualFile != null) {
+            OpenFileDescriptor(project, virtualFile, line, col).navigate(true)
+        } else {
+            Messages.showErrorDialog(project, "File not found: $filePath", "Navigation Error")
+        }
+    }
+}

--- a/jetbrains-go-tabletest-viewer/src/main/resources/META-INF/plugin.xml
+++ b/jetbrains-go-tabletest-viewer/src/main/resources/META-INF/plugin.xml
@@ -1,0 +1,20 @@
+<idea-plugin>
+    <id>com.github.mypkg.jetbrains-go-tabletest-viewer</id>
+    <name>Test Table Viewer</name>
+    <vendor>MyPkg</vendor>
+
+    <description><![CDATA[
+    Viewer for Go table driven tests.
+    ]]></description>
+
+    <depends>com.intellij.modules.platform</depends>
+
+    <extensions defaultExtensionNs="com.intellij">
+        <toolWindow id="Table Tests" secondary="true" anchor="right"
+                    factoryClass="com.github.mypkg.ui.TableTestToolWindowFactory"/>
+
+        <applicationConfigurable parentId="tools" instance="com.github.mypkg.settings.AppSettingsConfigurable"
+                                 id="com.github.mypkg.settings.AppSettingsConfigurable"
+                                 displayName="Test Table Viewer"/>
+    </extensions>
+</idea-plugin>

--- a/jetbrains-go-tabletest-viewer/src/test/kotlin/com/github/mypkg/model/ParserTest.kt
+++ b/jetbrains-go-tabletest-viewer/src/test/kotlin/com/github/mypkg/model/ParserTest.kt
@@ -1,0 +1,65 @@
+package com.github.mypkg.model
+
+import com.google.gson.Gson
+import org.junit.Test
+import org.junit.Assert.*
+
+class ParserTest {
+
+    @Test
+    fun testJsonParsing() {
+        val json = """
+{
+  "version": 1,
+  "packages": [
+    {
+      "importPath": "github.com/my/project/pkg",
+      "files": [
+        {
+          "path": "foo_test.go",
+          "tests": [
+            {
+              "func": "TestSomething",
+              "cases": [
+                {
+                  "name": "ok",
+                  "desc": "should return true",
+                  "line": 42,
+                  "col": 3,
+                  "source": "..."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+        """.trimIndent()
+
+        val result = Gson().fromJson(json, TestListResult::class.java)
+
+        assertNotNull(result)
+        assertEquals(1, result.version)
+        assertEquals(1, result.packages.size)
+
+        val pkg = result.packages[0]
+        assertEquals("github.com/my/project/pkg", pkg.importPath)
+        assertEquals(1, pkg.files.size)
+
+        val file = pkg.files[0]
+        assertEquals("foo_test.go", file.path)
+        assertEquals(1, file.tests.size)
+
+        val test = file.tests[0]
+        assertEquals("TestSomething", test.funcName)
+        assertEquals(1, test.cases.size)
+
+        val case = test.cases[0]
+        assertEquals("ok", case.name)
+        assertEquals("should return true", case.desc)
+        assertEquals(42, case.line)
+        assertEquals(3, case.col)
+    }
+}

--- a/jetbrains-go-tabletest-viewer/test_output.txt
+++ b/jetbrains-go-tabletest-viewer/test_output.txt
@@ -1,0 +1,27 @@
+> Task :checkKotlinGradlePluginConfigurationErrors
+> Task :initializeIntelliJPlugin SKIPPED
+> Task :patchPluginXml UP-TO-DATE
+
+> Task :verifyPluginConfiguration
+[gradle-intellij-plugin :verifyPluginConfiguration] The following plugin configuration issues were found:
+- The dependency on the Kotlin Standard Library (stdlib) is automatically added when using the Gradle Kotlin plugin and may conflict with the version provided with the IntelliJ Platform, see: https://jb.gg/intellij-platform-kotlin-stdlib
+See: https://jb.gg/intellij-platform-versions
+
+> Task :compileKotlin UP-TO-DATE
+> Task :compileJava NO-SOURCE
+> Task :processResources UP-TO-DATE
+> Task :classes UP-TO-DATE
+> Task :instrumentCode UP-TO-DATE
+> Task :instrumentedJar UP-TO-DATE
+> Task :jar UP-TO-DATE
+> Task :compileTestKotlin UP-TO-DATE
+> Task :compileTestJava NO-SOURCE
+> Task :processTestResources NO-SOURCE
+> Task :testClasses UP-TO-DATE
+> Task :instrumentTestCode UP-TO-DATE
+> Task :classpathIndexCleanup
+> Task :prepareTestingSandbox UP-TO-DATE
+> Task :test UP-TO-DATE
+
+BUILD SUCCESSFUL in 1s
+13 actionable tasks: 3 executed, 10 up-to-date

--- a/jetbrains-go-tabletest-viewer/test_output_2.txt
+++ b/jetbrains-go-tabletest-viewer/test_output_2.txt
@@ -1,0 +1,29 @@
+> Task :checkKotlinGradlePluginConfigurationErrors
+> Task :initializeIntelliJPlugin
+> Task :patchPluginXml
+
+> Task :verifyPluginConfiguration
+[gradle-intellij-plugin :verifyPluginConfiguration] The following plugin configuration issues were found:
+- The dependency on the Kotlin Standard Library (stdlib) is automatically added when using the Gradle Kotlin plugin and may conflict with the version provided with the IntelliJ Platform, see: https://jb.gg/intellij-platform-kotlin-stdlib
+See: https://jb.gg/intellij-platform-versions
+
+> Task :processResources
+> Task :processTestResources NO-SOURCE
+> Task :compileKotlin
+> Task :compileJava NO-SOURCE
+> Task :classes
+> Task :instrumentCode
+> Task :instrumentedJar
+> Task :jar
+> Task :prepareTestingSandbox
+> Task :compileTestKotlin
+> Task :compileTestJava NO-SOURCE
+> Task :testClasses UP-TO-DATE
+> Task :instrumentTestCode
+> Task :classpathIndexCleanup
+
+> Task :test
+CompileCommand: exclude com/intellij/openapi/vfs/impl/FilePartNodeRoot.trieDescend bool exclude = true
+
+BUILD SUCCESSFUL in 8s
+14 actionable tasks: 14 executed


### PR DESCRIPTION
Implemented a JetBrains IDE plugin to view and navigate Go table-driven tests.
- Uses external `testlist` CLI (configurable in Settings).
- Parses JSON output and displays a tree view in "Table Tests" tool window.
- Supports filtering and navigation (double-click to jump).
- Implements background execution with cancellation support.
- Configured for IntelliJ Platform 2024.1.

---
*PR created automatically by Jules for task [3150633909441881034](https://jules.google.com/task/3150633909441881034) started by @gyvm*