### PR TITLE
feat(fullscreen-alert): macOS全画面通知アプリ

### DIFF
--- a/fullscreen-alert/.gitignore
+++ b/fullscreen-alert/.gitignore
@@ -1,0 +1,6 @@
+FullScreenAlert.xcodeproj/
+build/
+.build/
+DerivedData/
+*.xcworkspace
+xcuserdata/

--- a/fullscreen-alert/ExportOptions-AppStore.plist
+++ b/fullscreen-alert/ExportOptions-AppStore.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>destination</key>
+	<string>upload</string>
+</dict>
+</plist>

--- a/fullscreen-alert/ExportOptions-Direct.plist
+++ b/fullscreen-alert/ExportOptions-Direct.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>developer-id</string>
+</dict>
+</plist>

--- a/fullscreen-alert/FullScreenAlert/AppDelegate.swift
+++ b/fullscreen-alert/FullScreenAlert/AppDelegate.swift
@@ -1,0 +1,30 @@
+import AppKit
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private(set) var isNotificationMode = false
+
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        if CLIArgumentParser.parse() != nil {
+            isNotificationMode = true
+            NSApp.setActivationPolicy(.accessory)
+        } else {
+            NSApp.setActivationPolicy(.regular)
+        }
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        guard let params = CLIArgumentParser.parse() else { return }
+
+        DispatchQueue.main.async {
+            for window in NSApp.windows where !AlertWindowController.shared.ownsWindow(window) {
+                window.close()
+            }
+        }
+
+        AlertWindowController.shared.showAlert(params: params, terminateOnClose: true)
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
+}

--- a/fullscreen-alert/FullScreenAlert/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/fullscreen-alert/FullScreenAlert/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fullscreen-alert/FullScreenAlert/FullScreenAlert.entitlements
+++ b/fullscreen-alert/FullScreenAlert/FullScreenAlert.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+</dict>
+</plist>

--- a/fullscreen-alert/FullScreenAlert/FullScreenAlertApp.swift
+++ b/fullscreen-alert/FullScreenAlert/FullScreenAlertApp.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+@main
+struct FullScreenAlertApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        WindowGroup {
+            if !appDelegate.isNotificationMode {
+                SettingsView()
+            }
+        }
+        .defaultSize(width: 420, height: 340)
+    }
+}

--- a/fullscreen-alert/FullScreenAlert/Info.plist
+++ b/fullscreen-alert/FullScreenAlert/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>ja</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key>
+	<string>FullScreenAlert</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.utilities</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2026 tansaku. All rights reserved.</string>
+</dict>
+</plist>

--- a/fullscreen-alert/FullScreenAlert/Intent/ShowFullScreenAlertIntent.swift
+++ b/fullscreen-alert/FullScreenAlert/Intent/ShowFullScreenAlertIntent.swift
@@ -1,0 +1,50 @@
+import AppIntents
+import AppKit
+
+@available(macOS 13.0, *)
+struct ShowFullScreenAlertIntent: AppIntent {
+    static var title: LocalizedStringResource = "全画面通知を表示"
+    static var description = IntentDescription("全画面に通知を表示します")
+
+    @Parameter(title: "タイトル")
+    var alertTitle: String?
+
+    @Parameter(title: "メッセージ")
+    var alertMessage: String?
+
+    @Parameter(title: "背景色 (HEX)")
+    var alertColor: String?
+
+    static var openAppWhenRun: Bool = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        let defaults = AlertParameters.loadDefaults()
+        let params = AlertParameters(
+            title: alertTitle?.isEmpty == false ? alertTitle! : defaults.title,
+            message: alertMessage?.isEmpty == false ? alertMessage! : defaults.message,
+            colorHex: alertColor?.isEmpty == false ? alertColor! : defaults.colorHex,
+            displayTarget: defaults.displayTarget
+        )
+
+        NSApp.setActivationPolicy(.accessory)
+        AlertWindowController.shared.showAlert(params: params, terminateOnClose: true)
+
+        return .result()
+    }
+}
+
+@available(macOS 13.0, *)
+struct FullScreenAlertShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: ShowFullScreenAlertIntent(),
+            phrases: [
+                "全画面通知を表示 \(.applicationName)",
+                "Show alert \(.applicationName)"
+            ],
+            shortTitle: "全画面通知",
+            systemImageName: "exclamationmark.triangle.fill"
+        )
+    }
+}

--- a/fullscreen-alert/FullScreenAlert/Models/AlertParameters.swift
+++ b/fullscreen-alert/FullScreenAlert/Models/AlertParameters.swift
@@ -1,0 +1,59 @@
+import Foundation
+import AppKit
+
+enum DisplayTarget: String, CaseIterable {
+    case mainOnly = "main"
+    case allDisplays = "all"
+}
+
+struct AlertParameters {
+    var title: String
+    var message: String
+    var colorHex: String
+    var displayTarget: DisplayTarget
+
+    static let fallbackTitle = "Alert"
+    static let fallbackMessage = ""
+    static let fallbackColorHex = "#FF4444"
+    static let fallbackDisplayTarget = DisplayTarget.mainOnly
+
+    static func loadDefaults() -> AlertParameters {
+        let ud = UserDefaults.standard
+        return AlertParameters(
+            title: ud.string(forKey: "defaultTitle") ?? fallbackTitle,
+            message: ud.string(forKey: "defaultMessage") ?? fallbackMessage,
+            colorHex: ud.string(forKey: "defaultColorHex") ?? fallbackColorHex,
+            displayTarget: DisplayTarget(rawValue: ud.string(forKey: "displayTarget") ?? "") ?? fallbackDisplayTarget
+        )
+    }
+
+    static func saveDefaults(_ params: AlertParameters) {
+        let ud = UserDefaults.standard
+        ud.set(params.title, forKey: "defaultTitle")
+        ud.set(params.message, forKey: "defaultMessage")
+        ud.set(params.colorHex, forKey: "defaultColorHex")
+        ud.set(params.displayTarget.rawValue, forKey: "displayTarget")
+    }
+
+    var nsColor: NSColor {
+        NSColor(hex: colorHex) ?? NSColor.systemRed
+    }
+}
+
+extension NSColor {
+    convenience init?(hex: String) {
+        var hexString = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if hexString.hasPrefix("#") {
+            hexString.removeFirst()
+        }
+        guard hexString.count == 6 else { return nil }
+        var rgb: UInt64 = 0
+        guard Scanner(string: hexString).scanHexInt64(&rgb) else { return nil }
+        self.init(
+            red: CGFloat((rgb >> 16) & 0xFF) / 255.0,
+            green: CGFloat((rgb >> 8) & 0xFF) / 255.0,
+            blue: CGFloat(rgb & 0xFF) / 255.0,
+            alpha: 1.0
+        )
+    }
+}

--- a/fullscreen-alert/FullScreenAlert/PrivacyInfo.xcprivacy
+++ b/fullscreen-alert/FullScreenAlert/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/fullscreen-alert/FullScreenAlert/Utilities/CLIArgumentParser.swift
+++ b/fullscreen-alert/FullScreenAlert/Utilities/CLIArgumentParser.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+struct CLIArgumentParser {
+    static func parse() -> AlertParameters? {
+        let args = CommandLine.arguments
+        guard args.count > 1 else { return nil }
+
+        let defaults = AlertParameters.loadDefaults()
+        var title = defaults.title
+        var message = defaults.message
+        var colorHex = defaults.colorHex
+
+        var i = 1
+        while i < args.count {
+            switch args[i] {
+            case "--title":
+                if i + 1 < args.count {
+                    i += 1
+                    title = args[i]
+                }
+            case "--message":
+                if i + 1 < args.count {
+                    i += 1
+                    message = args[i]
+                }
+            case "--color":
+                if i + 1 < args.count {
+                    i += 1
+                    colorHex = args[i]
+                }
+            default:
+                break
+            }
+            i += 1
+        }
+
+        return AlertParameters(
+            title: title,
+            message: message,
+            colorHex: colorHex,
+            displayTarget: defaults.displayTarget
+        )
+    }
+}

--- a/fullscreen-alert/FullScreenAlert/Views/AlertView.swift
+++ b/fullscreen-alert/FullScreenAlert/Views/AlertView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct AlertView: View {
+    let params: AlertParameters
+    let onClose: () -> Void
+
+    var body: some View {
+        ZStack {
+            Color(nsColor: params.nsColor)
+                .ignoresSafeArea()
+
+            VStack(spacing: 32) {
+                Spacer()
+
+                Text(params.title)
+                    .font(.system(size: 72, weight: .bold))
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+                    .shadow(radius: 4)
+
+                Text(params.message)
+                    .font(.system(size: 36))
+                    .foregroundColor(.white.opacity(0.9))
+                    .multilineTextAlignment(.center)
+
+                Spacer()
+
+                Button(action: onClose) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.title2)
+                        Text("閉じる")
+                            .font(.title2.weight(.medium))
+                    }
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 48)
+                    .padding(.vertical, 16)
+                    .background(.white.opacity(0.2))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.escape, modifiers: [])
+                .padding(.bottom, 80)
+            }
+            .padding(40)
+        }
+    }
+}

--- a/fullscreen-alert/FullScreenAlert/Views/AlertWindowController.swift
+++ b/fullscreen-alert/FullScreenAlert/Views/AlertWindowController.swift
@@ -1,0 +1,68 @@
+import AppKit
+import SwiftUI
+
+final class AlertWindowController {
+    static let shared = AlertWindowController()
+    private var windows: [NSWindow] = []
+    private(set) var isShowing = false
+    private var shouldTerminateOnClose = false
+
+    func showAlert(params: AlertParameters, terminateOnClose: Bool = false) {
+        self.shouldTerminateOnClose = terminateOnClose
+        self.isShowing = true
+
+        let screens: [NSScreen]
+        switch params.displayTarget {
+        case .mainOnly:
+            screens = [NSScreen.main ?? NSScreen.screens[0]]
+        case .allDisplays:
+            screens = NSScreen.screens
+        }
+
+        for screen in screens {
+            let window = NSWindow(
+                contentRect: screen.frame,
+                styleMask: .borderless,
+                backing: .buffered,
+                defer: false,
+                screen: screen
+            )
+            window.level = .screenSaver
+            window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+            window.isOpaque = true
+            window.hasShadow = false
+            window.setFrame(screen.frame, display: true)
+            window.contentView = NSHostingView(
+                rootView: AlertView(params: params, onClose: { [weak self] in
+                    self?.closeAll()
+                })
+            )
+            window.makeKeyAndOrderFront(nil)
+            windows.append(window)
+        }
+
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func ownsWindow(_ window: NSWindow) -> Bool {
+        windows.contains(window)
+    }
+
+    func closeAll() {
+        // ボタンのアクションハンドラ完了後にウィンドウを閉じる
+        // (ハンドラ中にビューが解放されるとEXC_BAD_ACCESSになるため)
+        let windowsToClose = windows
+        let terminate = shouldTerminateOnClose
+        windows.removeAll()
+        isShowing = false
+
+        DispatchQueue.main.async {
+            for window in windowsToClose {
+                window.orderOut(nil)
+            }
+            if terminate {
+                NSApp.terminate(nil)
+            }
+        }
+    }
+}

--- a/fullscreen-alert/FullScreenAlert/Views/SettingsView.swift
+++ b/fullscreen-alert/FullScreenAlert/Views/SettingsView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @AppStorage("defaultTitle") private var title = AlertParameters.fallbackTitle
+    @AppStorage("defaultMessage") private var message = AlertParameters.fallbackMessage
+    @AppStorage("defaultColorHex") private var colorHex = AlertParameters.fallbackColorHex
+    @AppStorage("displayTarget") private var displayTarget = DisplayTarget.mainOnly.rawValue
+
+    @State private var pickerColor: Color = .red
+
+    var body: some View {
+        Form {
+            Section("デフォルト値") {
+                TextField("タイトル", text: $title)
+                TextField("メッセージ", text: $message)
+
+                HStack {
+                    TextField("背景色 (HEX)", text: $colorHex)
+                        .frame(width: 150)
+                    ColorPicker("", selection: $pickerColor, supportsOpacity: false)
+                        .labelsHidden()
+                        .onChange(of: pickerColor) { newValue in
+                            colorHex = newValue.toHex()
+                        }
+                }
+            }
+
+            Section("表示ディスプレイ") {
+                Picker("", selection: $displayTarget) {
+                    Text("メインディスプレイのみ").tag(DisplayTarget.mainOnly.rawValue)
+                    Text("全ディスプレイ").tag(DisplayTarget.allDisplays.rawValue)
+                }
+                .pickerStyle(.radioGroup)
+                .labelsHidden()
+            }
+
+            Section {
+                Button("プレビュー") {
+                    let params = AlertParameters(
+                        title: title,
+                        message: message.isEmpty ? "プレビュー表示" : message,
+                        colorHex: colorHex,
+                        displayTarget: DisplayTarget(rawValue: displayTarget) ?? .mainOnly
+                    )
+                    AlertWindowController.shared.showAlert(params: params)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .frame(width: 420, height: 340)
+        .onAppear {
+            pickerColor = Color(nsColor: NSColor(hex: colorHex) ?? .systemRed)
+        }
+        .onChange(of: colorHex) { newValue in
+            if let c = NSColor(hex: newValue) {
+                pickerColor = Color(nsColor: c)
+            }
+        }
+    }
+}
+
+extension Color {
+    func toHex() -> String {
+        guard let components = NSColor(self).usingColorSpace(.sRGB)?.cgColor.components,
+              components.count >= 3 else {
+            return "#FF4444"
+        }
+        let r = Int(components[0] * 255)
+        let g = Int(components[1] * 255)
+        let b = Int(components[2] * 255)
+        return String(format: "#%02X%02X%02X", r, g, b)
+    }
+}

--- a/fullscreen-alert/Makefile
+++ b/fullscreen-alert/Makefile
@@ -1,0 +1,43 @@
+.PHONY: generate build run install clean archive export-appstore export-direct
+
+generate:
+	xcodegen generate
+
+build: generate
+	xcodebuild -project FullScreenAlert.xcodeproj \
+		-scheme FullScreenAlert \
+		-configuration Release \
+		-derivedDataPath build \
+		CODE_SIGNING_ALLOWED=NO
+
+run: build
+	open build/Build/Products/Release/FullScreenAlert.app
+
+install: build
+	cp -r build/Build/Products/Release/FullScreenAlert.app /Applications/
+
+# App Store / Direct 配布用アーカイブ
+archive: generate
+	xcodebuild -project FullScreenAlert.xcodeproj \
+		-scheme FullScreenAlert \
+		-configuration Release \
+		-archivePath build/FullScreenAlert.xcarchive \
+		archive
+
+# App Store 用エクスポート
+export-appstore: archive
+	xcodebuild -exportArchive \
+		-archivePath build/FullScreenAlert.xcarchive \
+		-exportOptionsPlist ExportOptions-AppStore.plist \
+		-exportPath build/export-appstore
+
+# 直接配布用エクスポート（Developer ID署名 + 公証）
+export-direct: archive
+	xcodebuild -exportArchive \
+		-archivePath build/FullScreenAlert.xcarchive \
+		-exportOptionsPlist ExportOptions-Direct.plist \
+		-exportPath build/export-direct
+
+clean:
+	rm -rf build/
+	rm -rf FullScreenAlert.xcodeproj

--- a/fullscreen-alert/project.yml
+++ b/fullscreen-alert/project.yml
@@ -1,0 +1,39 @@
+name: FullScreenAlert
+options:
+  bundleIdPrefix: com.tansaku
+  deploymentTarget:
+    macOS: "13.0"
+  createIntermediateGroups: true
+targets:
+  FullScreenAlert:
+    type: application
+    platform: macOS
+    sources:
+      - FullScreenAlert
+    settings:
+      base:
+        SWIFT_VERSION: "5.9"
+        PRODUCT_BUNDLE_IDENTIFIER: com.tansaku.fullscreen-alert
+        MACOSX_DEPLOYMENT_TARGET: "13.0"
+        INFOPLIST_FILE: FullScreenAlert/Info.plist
+        CODE_SIGN_ENTITLEMENTS: FullScreenAlert/FullScreenAlert.entitlements
+        ENABLE_HARDENED_RUNTIME: YES
+        GENERATE_INFOPLIST_FILE: NO
+        CURRENT_PROJECT_VERSION: 1
+        MARKETING_VERSION: "1.0.0"
+      configs:
+        Release:
+          CODE_SIGN_IDENTITY: "Apple Distribution"
+          CODE_SIGN_STYLE: Automatic
+        Debug:
+          CODE_SIGN_IDENTITY: "-"
+          CODE_SIGN_STYLE: Automatic
+schemes:
+  FullScreenAlert:
+    build:
+      targets:
+        FullScreenAlert: all
+    run:
+      config: Debug
+    archive:
+      config: Release


### PR DESCRIPTION
## Summary

macOS向けの全画面通知アプリ。CLI引数やApple ショートカット（App Intents）から呼び出せるシンプルな通知ツール。

## Changes

- **Swift/SwiftUI + XcodeGen** 構成で新規プロジェクト作成
- **CLI通知モード**: `--title`, `--message`, `--color` 引数で全画面通知表示（Dockアイコンなし、閉じるとプロセス終了）
- **設定モード**: 引数なし起動でデフォルト値の設定画面（UserDefaults永続化）
- **App Intents**: ショートカットアプリから「全画面通知を表示」アクションが利用可能
- **複数ディスプレイ対応**: メインのみ / 全ディスプレイの切替（設定画面で変更）
- **App Sandbox対応**: App Store配布を見据えたSandbox有効構成
- **プライバシーマニフェスト**: UserDefaults使用宣言（`CA92.1`）
- **App Store / 直接配布** 両対応のエクスポート設定・Makefile

## 使い方

```bash
cd fullscreen-alert

# ビルド（XcodeGen + xcodebuild）
make build

# CLI通知
./build/Build/Products/Release/FullScreenAlert.app/Contents/MacOS/FullScreenAlert \
  --title "会議まで5分" --message "Zoomを開いてください" --color "#FF4444"

# 設定画面
open build/Build/Products/Release/FullScreenAlert.app
```

## 後続作業（TODO）

### 必須（公開前）
- [ ] `project.yml` に `DEVELOPMENT_TEAM` を設定（Apple Developer Team ID）
- [ ] Xcode で Signing & Capabilities を設定し `make archive` 成功を確認
- [ ] アプリアイコンの作成・配置
- [ ] README.md 作成（インストール方法、スクリーンショット）

### App Store 公開
- [ ] App Store Connect でアプリ登録・メタデータ入力
- [ ] `make export-appstore` でアップロード
- [ ] スクリーンショット撮影・審査提出

### 自サイト配布
- [ ] `make export-direct` で Developer ID 署名
- [ ] `xcrun notarytool` で公証
- [ ] DMG 作成スクリプトの追加
- [ ] ダウンロードページ作成

### 改善（任意）
- [ ] メニューバーにアプリ名・Aboutメニュー表示
- [ ] 通知音オプション
- [ ] アニメーション（フェードイン/アウト）
- [ ] Homebrew Cask での配布

## Test plan

- [x] `make build` 成功
- [x] CLI引数あり → 全画面通知表示、Dockアイコンなし、閉じるとプロセス終了
- [x] 引数なし → 設定画面表示、Dockアイコンあり
- [x] 設定画面のプレビュー → 閉じる → 設定画面が残る（クラッシュしない）
- [x] App Sandbox 有効でビルド・動作確認
- [ ] App Intents がショートカットアプリに表示される（要署名・インストール）
- [ ] 複数ディスプレイでの全画面表示